### PR TITLE
status did non change on editing Employee status, fixed now in Employ…

### DIFF
--- a/app/Shop/Employees/Repositories/EmployeeRepository.php
+++ b/app/Shop/Employees/Repositories/EmployeeRepository.php
@@ -77,13 +77,15 @@ class EmployeeRepository extends BaseRepository implements EmployeeRepositoryInt
     {
         $fields = [
             "name" => $params['name'],
-            "email" => $params['email']
+            "email" => $params['email'],
+            "status" => $params['status']
         ];
 
         if (isset($params['password']) && !is_null($params['password'])) {
             $fields = [
                 "name" => $params['name'],
                 "email" => $params['email'],
+                "status" => $params['status'],
                 "password" => bcrypt($params['password'])
             ];
         }


### PR DESCRIPTION
# Fix: Employee status doesn't change when employee is edited

## after changing the status from disable to enable and after an update the status doesn't change.

Admin panel --> employee tab --> List employee --> edit

Solution: just added "status" => $params['status'] in updateEmployee function

link: [ISSUE 41](https://github.com/Laracommerce/laracom/issues/41)