### PR TITLE
fix artisan create tables by utf8mb4

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Schema;
 use Laravel\Cashier\Cashier;
 
 class AppServiceProvider extends ServiceProvider
@@ -14,6 +15,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        Schema::defaultStringLength(191);
         Cashier::useCurrency(config('cart.currency'), config('cart.currency_symbol'));
     }
 


### PR DESCRIPTION
```bash
zoujiaqing@debian:~/projects/laracom$ php artisan migrate --seed

In Connection.php line 664:
                                                                                                                                                                      
  SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was too long; max key length is 767 bytes (SQL: alter table `password_resets` add index `pas  
  sword_resets_email_index`(`email`))                                                                                                                                 
                                                                                                                                                                      

In PDOStatement.php line 143:
                                                                                                                   
  SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was too long; max key length is 767 bytes  
                                                                                                                   

In PDOStatement.php line 141:
                                                                                                                   
  SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was too long; max key length is 767 bytes  
```