### PR TITLE
Develop

### DIFF
--- a/app/Http/Controllers/Admin/EmployeeController.php
+++ b/app/Http/Controllers/Admin/EmployeeController.php
@@ -6,7 +6,9 @@ use App\Shop\Admins\Requests\CreateEmployeeRequest;
 use App\Shop\Admins\Requests\UpdateEmployeeRequest;
 use App\Shop\Employees\Repositories\EmployeeRepository;
 use App\Shop\Employees\Repositories\Interfaces\EmployeeRepositoryInterface;
+use App\Shop\Roles\Repositories\RoleRepositoryInterface;
 use App\Http\Controllers\Controller;
+
 
 class EmployeeController extends Controller
 {
@@ -14,14 +16,19 @@ class EmployeeController extends Controller
      * @var EmployeeRepositoryInterface
      */
     private $employeeRepo;
+    /**
+     * @var RoleRepositoryInterface
+     */
+    private $roleRepo;
 
     /**
      * EmployeeController constructor.
      * @param EmployeeRepositoryInterface $employeeRepository
      */
-    public function __construct(EmployeeRepositoryInterface $employeeRepository)
+    public function __construct(EmployeeRepositoryInterface $employeeRepository, RoleRepositoryInterface $roleRepository)
     {
         $this->employeeRepo = $employeeRepository;
+        $this->roleRepo = $roleRepository;
     }
 
     /**
@@ -82,7 +89,16 @@ class EmployeeController extends Controller
     public function edit(int $id)
     {
         $employee = $this->employeeRepo->findEmployeeById($id);
-        return view('admin.employees.edit', ['employee' => $employee]);
+        $allRoles = $this->roleRepo->listRoles('created_at', 'desc');
+        $isCurrentUser = $this->employeeRepo->isAuthUser($employee);
+
+        return view(
+          'admin.employees.edit', [
+            'employee' => $employee,
+            'allRoles' => $allRoles,
+            'isCurrentUser' => $isCurrentUser,
+            'selectedIds' => $employee->roles()->pluck('role_id')->all()
+        ]);
     }
 
     /**
@@ -95,12 +111,19 @@ class EmployeeController extends Controller
     public function update(UpdateEmployeeRequest $request, $id)
     {
         $employee = $this->employeeRepo->findEmployeeById($id);
+        $isCurrentUser = $this->employeeRepo->isAuthUser($employee);
 
         $empRepo = new EmployeeRepository($employee);
         $empRepo->updateEmployee($request->except('_token', '_method', 'password'));
 
         if ($request->has('password')) {
             $empRepo->updateEmployee(['password' => bcrypt($request->input('password'))]);
+        }
+
+        if ($request->has('roles') And !$isCurrentUser) {
+            $employee->roles()->sync($request->input('roles'));
+        } else if(!$isCurrentUser){
+            $employee->roles()->detach($request->input('roles'));
         }
 
         $request->session()->flash('message', 'Update successful');

--- a/app/Providers/RepositoryServiceProvider.php
+++ b/app/Providers/RepositoryServiceProvider.php
@@ -36,6 +36,8 @@ use App\Shop\Products\Repositories\Interfaces\ProductRepositoryInterface;
 use App\Shop\Products\Repositories\ProductRepository;
 use App\Shop\Provinces\Repositories\Interfaces\ProvinceRepositoryInterface;
 use App\Shop\Provinces\Repositories\ProvinceRepository;
+use App\Shop\Roles\Repositories\RoleRepository;
+use App\Shop\Roles\Repositories\RoleRepositoryInterface;
 use Illuminate\Support\ServiceProvider;
 
 class RepositoryServiceProvider extends ServiceProvider
@@ -125,6 +127,11 @@ class RepositoryServiceProvider extends ServiceProvider
         $this->app->bind(
             CartRepositoryInterface::class,
             CartRepository::class
+        );
+
+        $this->app->bind(
+            RoleRepositoryInterface::class,
+            RoleRepository::class
         );
     }
 }

--- a/app/Shop/Employees/Repositories/EmployeeRepository.php
+++ b/app/Shop/Employees/Repositories/EmployeeRepository.php
@@ -8,6 +8,8 @@ use App\Shop\Employees\Exceptions\EmployeeNotFoundException;
 use App\Shop\Employees\Repositories\Interfaces\EmployeeRepositoryInterface;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
+
 
 class EmployeeRepository extends BaseRepository implements EmployeeRepositoryInterface
 {
@@ -100,4 +102,20 @@ class EmployeeRepository extends BaseRepository implements EmployeeRepositoryInt
     {
         return $this->model->hasRole($roleName);
     }
+
+    /**
+     * @param Employee $employee
+     * @return bool
+     */
+    public function isAuthUser(Employee $employee): bool
+    {
+        $isAuthUser = false;
+        if (Auth::guard('admin')->user()->id == $employee->id)
+        {
+           $isAuthUser = true;
+        }
+        return $isAuthUser;
+    }
+
+
 }

--- a/app/Shop/Employees/Repositories/Interfaces/EmployeeRepositoryInterface.php
+++ b/app/Shop/Employees/Repositories/Interfaces/EmployeeRepositoryInterface.php
@@ -21,4 +21,6 @@ interface EmployeeRepositoryInterface extends BaseRepositoryInterface
     public function listRoles() : Collection;
 
     public function hasRole(string $roleName) : bool;
+
+    public function isAuthUser(Employee $employee): bool;
 }

--- a/app/Shop/Roles/Repositories/RoleRepository.php
+++ b/app/Shop/Roles/Repositories/RoleRepository.php
@@ -1,19 +1,16 @@
 <?php
-
 namespace App\Shop\Roles\Repositories;
-
 use App\Shop\Base\BaseRepository;
 use App\Shop\Roles\Exceptions\CreateRoleErrorException;
 use App\Shop\Roles\Role;
 use Illuminate\Database\QueryException;
-
+use Illuminate\Support\Collection;
 class RoleRepository extends BaseRepository implements RoleRepositoryInterface
 {
     /**
      * @var Role
      */
     protected $model;
-
     /**
      * RoleRepository constructor.
      * @param Role $role
@@ -23,7 +20,17 @@ class RoleRepository extends BaseRepository implements RoleRepositoryInterface
         parent::__construct($role);
         $this->model = $role;
     }
-
+    /**
+     * List all Roles
+     *
+     * @param string $order
+     * @param string $sort
+     * @return Collection
+     */
+     public function listRoles(string $order = 'id', string $sort = 'desc') : Collection
+     {
+          return $this->all(['*'], $order, $sort);
+     }
     /**
      * @param array $data
      * @return Role

--- a/app/Shop/Roles/Repositories/RoleRepositoryInterface.php
+++ b/app/Shop/Roles/Repositories/RoleRepositoryInterface.php
@@ -4,8 +4,13 @@ namespace App\Shop\Roles\Repositories;
 
 use App\Shop\Base\Interfaces\BaseRepositoryInterface;
 use App\Shop\Roles\Role;
+use Illuminate\Support\Collection;
+
 
 interface RoleRepositoryInterface extends BaseRepositoryInterface
 {
     public function createRole(array $data) : Role;
+
+    public function listRoles(string $order = 'id', string $sort = 'desc') : Collection;
+
 }

--- a/database/seeds/EmployeesTableSeeder.php
+++ b/database/seeds/EmployeesTableSeeder.php
@@ -13,7 +13,6 @@ class EmployeesTableSeeder extends Seeder
                 $employee->roles()->save($role);
             });
         });
-
         factory(Employee::class)->create();
     }
 }

--- a/resources/views/admin/employees/edit.blade.php
+++ b/resources/views/admin/employees/edit.blade.php
@@ -7,31 +7,40 @@
         <div class="box">
             <form action="{{ route('admin.employees.update', $employee->id) }}" method="post" class="form">
                 <div class="box-body">
-                    {{ csrf_field() }}
-                    <input type="hidden" name="_method" value="put">
-                    <div class="form-group">
-                        <label for="name">Name <span class="text-danger">*</span></label>
-                        <input type="text" name="name" id="name" placeholder="Name" class="form-control" value="{!! $employee->name ?: old('name')  !!}">
-                    </div>
-                    <div class="form-group">
-                        <label for="email">Email <span class="text-danger">*</span></label>
-                        <div class="input-group">
-                            <span class="input-group-addon">@</span>
-                            <input type="text" name="email" id="email" placeholder="Email" class="form-control" value="{!! $employee->email ?: old('email')  !!}">
+                   <div class="row">
+                        {{ csrf_field() }}
+                        <input type="hidden" name="_method" value="put">
+                        <div class="col-md-8">
+                            <div class="form-group">
+                                <label for="name">Name <span class="text-danger">*</span></label>
+                                <input type="text" name="name" id="name" placeholder="Name" class="form-control" value="{!! $employee->name ?: old('name')  !!}">
+                            </div>
+                            <div class="form-group">
+                                <label for="email">Email <span class="text-danger">*</span></label>
+                                <div class="input-group">
+                                    <span class="input-group-addon">@</span>
+                                    <input type="text" name="email" id="email" placeholder="Email" class="form-control" value="{!! $employee->email ?: old('email')  !!}">
+                                </div>
+                            </div>
+                            <div class="form-group">
+                                <label for="password">Password <span class="text-danger">*</span></label>
+                                <input type="password" name="password" id="password" placeholder="xxxxx" class="form-control">
+                            </div>
+                            <div class="form-group">
+                                <label for="status">Status </label>
+                                <select name="status" id="status" class="form-control">
+                                    <option value="0" @if($employee->status == 0) selected="selected" @endif>Disable</option>
+                                    <option value="1" @if($employee->status == 1) selected="selected" @endif>Enable</option>
+                                </select>
+                            </div>
                         </div>
-                    </div>
-                    <div class="form-group">
-                        <label for="password">Password <span class="text-danger">*</span></label>
-                        <input type="password" name="password" id="password" placeholder="xxxxx" class="form-control">
-                    </div>
-                    <div class="form-group">
-                        <label for="status">Status </label>
-                        <select name="status" id="status" class="form-control">
-                            <option value="0" @if($employee->status == 0) selected="selected" @endif>Disable</option>
-                            <option value="1" @if($employee->status == 1) selected="selected" @endif>Enable</option>
-                        </select>
-                    </div>
+                        <div class="col-md-4">
+                            <label for="roles">Roles</label>
+                            @include('admin.shared.roles', ['allRoles' => $allRoles])
+                        </div>
+                   </div>
                 </div>
+
                 <!-- /.box-body -->
                 <div class="box-footer">
                     <div class="btn-group">

--- a/resources/views/admin/employees/show.blade.php
+++ b/resources/views/admin/employees/show.blade.php
@@ -13,6 +13,7 @@
                             <td class="col-md-4">ID</td>
                             <td class="col-md-4">Name</td>
                             <td class="col-md-4">Email</td>
+                            <td class="col-md-4">Roles</td>
                         </tr>
                     </tbody>
                     <tbody>
@@ -20,6 +21,9 @@
                         <td>{{ $employee->id }}</td>
                         <td>{{ $employee->name }}</td>
                         <td>{{ $employee->email }}</td>
+                        <td>
+                            {{ $employee->roles()->get()->implode('name', ', ') }}
+                        </td>
                     </tr>
                     </tbody>
                 </table>

--- a/resources/views/admin/shared/roles.blade.php
+++ b/resources/views/admin/shared/roles.blade.php
@@ -1,0 +1,18 @@
+<ul class="list-unstyled">
+    @foreach($allRoles as $role)
+        <li>
+            <div class="checkbox">
+                <label>
+                    <input
+                            type="checkbox"
+                            @if(isset($selectedIds) && in_array($role->id, $selectedIds))checked="checked" @endif
+                            @if($isCurrentUser) disabled @endif
+                            name="roles[]"
+                            value="{{ $role->id }}">
+                    {{ $role->name }}
+                </label>
+            </div>
+        </li>
+
+    @endforeach
+</ul>

--- a/tests/Feature/Admin/Employees/EmployeeFeatureTest.php
+++ b/tests/Feature/Admin/Employees/EmployeeFeatureTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature\Admin\Employees;
 
 use App\Shop\Employees\Employee;
-use App\Shop\Roles\Role;
 use Illuminate\Auth\Events\Lockout;
 use Tests\TestCase;
 
@@ -258,22 +257,4 @@ class EmployeeFeatureTest extends TestCase
 
         $this->assertDatabaseHas('employees', $created->all());
     }
-
-    /** @test */
-    public function it_can_attach_or_detach_the_employee_role_()
-    {
-        $employee = factory(Employee::class)->create();
-        $role = factory(Role::class)->create();
-
-        $employee->roles()->attach($role);
-        $this->assertTrue($employee->hasRole($role->name));
-
-        $employee->roles()->detach($role);
-        $this->assertFalse($employee->hasRole($role->name));
-
-    }
-
-
-
-
 }

--- a/tests/Feature/Admin/Employees/EmployeeFeatureTest.php
+++ b/tests/Feature/Admin/Employees/EmployeeFeatureTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Admin\Employees;
 
 use App\Shop\Employees\Employee;
+use App\Shop\Roles\Role;
 use Illuminate\Auth\Events\Lockout;
 use Tests\TestCase;
 
@@ -17,7 +18,7 @@ class EmployeeFeatureTest extends TestCase
             ->assertStatus(302)
             ->assertRedirect(route('admin.dashboard'));
     }
-    
+
     /** @test */
     public function it_can_show_the_admin_login_form()
     {
@@ -130,7 +131,7 @@ class EmployeeFeatureTest extends TestCase
             ->get(route('admin.employees.edit', 999))
             ->assertStatus(404);
     }
-    
+
     /** @test */
     public function it_errors_when_looking_for_an_employee_that_is_not_found()
     {
@@ -138,7 +139,7 @@ class EmployeeFeatureTest extends TestCase
             ->get(route('admin.employees.show', 999))
             ->assertStatus(404);
     }
-    
+
     /** @test */
     public function it_can_list_all_the_employees()
     {
@@ -179,7 +180,7 @@ class EmployeeFeatureTest extends TestCase
             ->assertStatus(302)
             ->assertSessionHas(['errors']);
     }
-    
+
     /** @test */
     public function it_can_only_soft_delete_an_employee()
     {
@@ -212,7 +213,7 @@ class EmployeeFeatureTest extends TestCase
         $collection = collect($update)->except('password');
         $this->assertDatabaseHas('employees', $collection->all());
     }
-    
+
     /** @test */
     public function it_can_update_the_employee()
     {
@@ -229,7 +230,7 @@ class EmployeeFeatureTest extends TestCase
 
         $this->assertDatabaseHas('employees', $update);
     }
-    
+
     /** @test */
     public function it_can_show_the_employee()
     {
@@ -238,7 +239,7 @@ class EmployeeFeatureTest extends TestCase
             ->assertStatus(200)
             ->assertViewHas('employee');
     }
-    
+
     /** @test */
     public function it_can_create_an_employee()
     {
@@ -257,4 +258,22 @@ class EmployeeFeatureTest extends TestCase
 
         $this->assertDatabaseHas('employees', $created->all());
     }
+
+    /** @test */
+    public function it_can_attach_or_detach_the_employee_role_()
+    {
+        $employee = factory(Employee::class)->create();
+        $role = factory(Role::class)->create();
+
+        $employee->roles()->attach($role);
+        $this->assertTrue($employee->hasRole($role->name));
+
+        $employee->roles()->detach($role);
+        $this->assertFalse($employee->hasRole($role->name));
+
+    }
+
+
+
+
 }

--- a/tests/Unit/Employees/EmployeeUnitTest.php
+++ b/tests/Unit/Employees/EmployeeUnitTest.php
@@ -29,4 +29,17 @@ class EmployeeUnitTest extends TestCase
             $this->assertEquals($userRole->name, $role->name);
         });
     }
+    /** @test */
+    public function it_can_attach_or_detach_the_employee_role_()
+    {
+        $employee = factory(Employee::class)->create();
+        $role = factory(Role::class)->create();
+
+        $employee->roles()->attach($role);
+        $this->assertTrue($employee->hasRole($role->name));
+
+        $employee->roles()->detach($role);
+        $this->assertFalse($employee->hasRole($role->name));
+
+    }
 }

--- a/tests/Unit/Employees/EmployeeUnitTest.php
+++ b/tests/Unit/Employees/EmployeeUnitTest.php
@@ -30,7 +30,7 @@ class EmployeeUnitTest extends TestCase
         });
     }
     /** @test */
-    public function it_can_attach_or_detach_the_employee_role_()
+    public function it_can_attach_or_detach_the_employee_role()
     {
         $employee = factory(Employee::class)->create();
         $role = factory(Role::class)->create();


### PR DESCRIPTION
# Feature - Add Role choice in "Employee Edit" - List of Employee Roles in "Employee Show" 

As a part of a bigger enhancement this can be a first step to create a multi-role feature for Laracom

## In admin panel the Employee authenticated as "Admin" can show the Roles

 Employee --> List Employee --> Show

## In admin panel the Employee authenticated as "Admin" can edit the Roles

Employee --> List Employee --> Edit

## In admin panel the Employee authenticated as "Admin" cannot edit his own Roles

Employee --> List Employee --> select the employee wherewith authenticated --> try to Edit

## Add a Unit Test

it_can_attach_or_detach_the_employee_role in EmployeeUnitTest

 link: [ISSUE 55](https://github.com/Laracommerce/laracom/issues/55)