### PR TITLE
#65 Update category.blade.php

### DIFF
--- a/resources/views/front/categories/category.blade.php
+++ b/resources/views/front/categories/category.blade.php
@@ -15,7 +15,7 @@
         <div class="row">
             <div class="category-top col-md-12">
                 <h2>{{ $category->name }}</h2>
-                {{ $category->description }}
+                {!! $category->description !!}
             </div>
         </div>
         <hr>


### PR DESCRIPTION
Update blade syntax to display unescaped character when category description is displayed. This is show the proper html rendered view by the browser.

# Displaying Unescaped Data

## Change blade syntax to use unescaped syntax, https://github.com/Laracommerce/laracom/issues/65