### PR TITLE
#70 Fix user address issues

### DIFF
--- a/app/Http/Controllers/Front/CustomerAddressController.php
+++ b/app/Http/Controllers/Front/CustomerAddressController.php
@@ -7,6 +7,7 @@ use App\Shop\Addresses\Requests\CreateAddressRequest;
 use App\Shop\Cities\Repositories\Interfaces\CityRepositoryInterface;
 use App\Shop\Countries\Repositories\Interfaces\CountryRepositoryInterface;
 use App\Shop\Customers\Repositories\Interfaces\CustomerRepositoryInterface;
+use App\Shop\Provinces\Repositories\Interfaces\ProvinceRepositoryInterface;
 use App\Http\Controllers\Controller;
 
 class CustomerAddressController extends Controller
@@ -15,17 +16,20 @@ class CustomerAddressController extends Controller
     private $customerRepo;
     private $countryRepo;
     private $cityRepo;
+    private $provinceRepo;
 
     public function __construct(
         AddressRepositoryInterface $addressRepository,
         CustomerRepositoryInterface $customerRepository,
         CountryRepositoryInterface $countryRepository,
-        CityRepositoryInterface $cityRepository
+        CityRepositoryInterface $cityRepository,
+        ProvinceRepositoryInterface $provinceRepository
     ) {
         $this->addressRepo = $addressRepository;
         $this->customerRepo = $customerRepository;
         $this->countryRepo = $countryRepository;
         $this->cityRepo = $cityRepository;
+        $this->provinceRepo = $provinceRepository;
     }
 
     /**
@@ -53,7 +57,9 @@ class CustomerAddressController extends Controller
         return view('front.customers.addresses.create', [
             'customers' => $this->customerRepo->listCustomers(),
             'customer' => $this->customerRepo->findCustomerById($customerId),
-            'countries' => $countries
+            'countries' => $countries,
+            'cities' => $this->cityRepo->listCities(),
+            'provinces' => $this->provinceRepo->listProvinces()
         ]);
     }
 

--- a/resources/views/front/accounts.blade.php
+++ b/resources/views/front/accounts.blade.php
@@ -108,9 +108,9 @@
                                             <td>{{$address->alias}}</td>
                                             <td>{{$address->address_1}}</td>
                                             <td>{{$address->address_1}}</td>
-                                            <td>{{$address->city_id}}</td>
-                                            <td>{{$address->province_id}}</td>
-                                            <td>{{$address->country_id}}</td>
+                                            <td>{{$address->city->name}}</td>
+                                            <td>{{$address->province->name}}</td>
+                                            <td>{{$address->country->name}}</td>
                                             <td>{{$address->zip}}</td>
                                         </tr>
                                     @endforeach

--- a/resources/views/front/customers/addresses/create.blade.php
+++ b/resources/views/front/customers/addresses/create.blade.php
@@ -22,6 +22,22 @@
                         <input type="text" name="address_2" id="address_2" placeholder="Address 2" class="form-control" value="{{ old('address_2') }}">
                     </div>
                     <div class="form-group">
+                        <label for="country_id">City </label>
+                        <select name="city_id" id="city_id" class="form-control select_city">
+                            @foreach($cities as $city)
+                                <option value="{{ $city->id }}">{{ $city->name }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="country_id">Province </label>
+                        <select name="province_id" id="province_id" class="form-control select_province">
+                            @foreach($provinces as $province)
+                                <option value="{{ $province->id }}">{{ $province->name }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="form-group">
                         <label for="country_id">Country </label>
                         <select name="country_id" id="country_id" class="form-control select2">
                             @foreach($countries as $country)
@@ -118,6 +134,18 @@
                 findProvinceOrState(countryId);
             });
             $('.select2').select2();
+
+            $('#city_id').on('change', function () {
+                cityId = $(this).val();
+                findProvinceOrState(countryId);
+            });
+            $('.select_city').select2();
+
+            $('#province_id').on('change', function () {
+                provinceId = $(this).val();
+                findProvinceOrState(countryId);
+            });
+            $('.select_province').select2();
         });
     </script>
 @endsection


### PR DESCRIPTION
# Fix user address issues

## Update form to contain city and province field so that the data saved can contain city_id and province_id to prevent breakages when order-address relationship is used.


NB: `City and Province can be properly implemented if loaded via jquery when the country is selected, and it loads the province that belongs to that country and also province to city. But this is just a minor fix to ensure no bug in this area.`
