### PR TITLE
Typo $employee should be $customer

### DIFF
--- a/app/Http/Controllers/Admin/Customers/CustomerController.php
+++ b/app/Http/Controllers/Admin/Customers/CustomerController.php
@@ -110,9 +110,9 @@ class CustomerController extends Controller
      */
     public function update(UpdateCustomerRequest $request, $id)
     {
-        $employee = $this->customerRepo->findCustomerById($id);
+        $customer = $this->customerRepo->findCustomerById($id);
 
-        $update = new CustomerRepository($employee);
+        $update = new CustomerRepository($customer);
         $data = $request->except('_method', '_token', 'password');
 
         if ($request->has('password')) {


### PR DESCRIPTION
Fixed a typo to make the code more clear

`$employee` variable should be `$customer`
