### PR TITLE
- Integrated spatie/phpunit-watcher

### DIFF
--- a/.phpunit-watcher.yml
+++ b/.phpunit-watcher.yml
@@ -1,0 +1,12 @@
+watch:
+  directories:
+  - app
+  - config
+  - routes
+  - tests
+  fileMask: '*.php'
+notifications:
+  passingTests: false
+  failingTests: true
+phpunit:
+  arguments: '--stop-on-failure'

--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,11 @@
         "shippo/shippo-php": "^1.4"
     },
     "require-dev": {
+        "filp/whoops": "~2.0",
         "fzaninotto/faker": "~1.4",
         "mockery/mockery": "~1.0",
         "phpunit/phpunit": "~7.0",
-        "filp/whoops": "~2.0"
+        "spatie/phpunit-watcher": "^1.6"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
# Integration of [spatie/phpunit-watcher](https://github.com/spatie/phpunit-watcher)

## Description of the PR with the link on the issue trying to solve
My PR solves issue #116 by integrating spatie/phpunit-watcher. This laravel packages is a huge benefit in the context of unit/integration testing.
Every code change will automatically trigger a test run.
You get instant feedback if your tests are broken.

In order to use phpunit-watcher, follow these steps:
```
composer install
vendor/bin/phpunit-watcher watch
```

You'll find the basic configuration in `.phpunit-watcher.yml`
For more information about the package and configuration possibilities have a look at the offical documentation.
https://github.com/spatie/phpunit-watcher

In order to show desktop notifications on a Linux system, you have to install `libnotify-bin`
```
sudo apt install libnotify-bin
```

Cheers
Sebastian