### PR TITLE
Make parent category input optional on admin side

### DIFF
--- a/app/Shop/Categories/Repositories/CategoryRepository.php
+++ b/app/Shop/Categories/Repositories/CategoryRepository.php
@@ -115,12 +115,23 @@ class CategoryRepository extends BaseRepository implements CategoryRepositoryInt
         }
 
         $merge = $collection->merge(compact('slug', 'cover'));
-        if (isset($params['parent'])) {
+
+        // set parent attribute default value if not set
+        $params['parent'] = $params['parent'] ?? 0;
+
+        // If parent category is not set on update
+        // just make current category as root
+        // else we need to find the parent
+        // and associate it as child
+        if ( (int)$params['parent'] == 0) {
+            $category->saveAsRoot();
+        } else {
             $parent = $this->findCategoryById($params['parent']);
             $category->parent()->associate($parent);
         }
 
         $category->update($merge->all());
+        
         return $category;
     }
 

--- a/resources/views/admin/categories/create.blade.php
+++ b/resources/views/admin/categories/create.blade.php
@@ -11,6 +11,7 @@
                     <div class="form-group">
                         <label for="parent">Parent Category</label>
                         <select name="parent" id="parent" class="form-control select2">
+                            <option value="">-- Select --</option>
                             @foreach($categories as $category)
                                 <option value="{{ $category->id }}">{{ $category->name }}</option>
                             @endforeach

--- a/resources/views/admin/categories/edit.blade.php
+++ b/resources/views/admin/categories/edit.blade.php
@@ -12,6 +12,7 @@
                     <div class="form-group">
                         <label for="parent">Parent Category</label>
                         <select name="parent" id="parent" class="form-control select2">
+                            <option value="0">No parent</option>
                             @foreach($categories as $cat)
                                 <option @if($cat->id == $category->parent_id) selected="selected" @endif value="{{$cat->id}}">{{$cat->name}}</option>
                             @endforeach


### PR DESCRIPTION
### Set selecting parent category optional

When you need to update or create a new category. 
The parent option is always set.
This is a fix for [#136](https://github.com/Laracommerce/laracom/issues/136)