### PR TITLE
Feature: Generate model and repository for base shop

### DIFF
--- a/app/Console/Commands/LaraStructure.php
+++ b/app/Console/Commands/LaraStructure.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+
+class LaraStructure extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'make:structure {model} {--m|migration}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'This command generate model and a base repository out of the box.';
+
+    /**
+     * Filesystem instance
+     * 
+     * @var string
+     */
+    protected $filesystem;
+
+    /**
+     * Default laracom folder
+     * 
+     * @var string
+     */
+    protected $folder;
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct(Filesystem $filesystem)
+    {
+        parent::__construct();
+        $this->filesystem = $filesystem;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        // Get model name from developer
+        $this->model = ucfirst($this->argument('model'));
+
+        // Get plural name for the given model
+        $pluralModel = str_plural($this->model);
+
+        // Check if the model already created
+        if ( $this->filesystem->exists(app_path("Shop/{$pluralModel}/{$this->model}.php")) ){
+            return $this->error("The given model already exists!");
+        }
+
+        // create all structured folders
+        $this->createFolders('Shop');
+
+        $this->createFile(
+            app_path('Console/Stubs/DummyRepository.stub'),
+            app_path("Shop/{$pluralModel}/Repositories/{$this->model}Repository.php")
+        );
+
+        $this->createFile(
+            app_path('Console/Stubs/DummyRepositoryInterface.stub'),
+            app_path("Shop/{$pluralModel}/Repositories/Interfaces/{$this->model}RepositoryInterface.php")
+        );
+
+        $this->info('File structure for ' . $this->model . ' created.');
+        
+        // Create Model under default instalation folder
+        $this->call('make:model', [
+            'name' => 'Shop/' . $pluralModel . '/' .$this->model,
+            '--migration' => $this->option('migration'),
+        ]);
+    }
+
+    /**
+     * Create source from dummy model name
+     * 
+     * @param  string $dummy        
+     * @param  string $destinationPath
+     * @return void
+     */
+    protected function createFile($dummySource, $destinationPath)
+    {
+        $pluralModel = str_plural($this->model);
+        $dummyRepository = $this->filesystem->get($dummySource);
+        $repositoryContent = str_replace(['Dummy', 'Dummies'], [$this->model, $pluralModel], $dummyRepository);
+        $this->filesystem->put($dummySource, $repositoryContent);
+        $this->filesystem->copy($dummySource, $destinationPath);
+        $this->filesystem->put($dummySource, $dummyRepository);
+    }
+
+    /**
+     * Create all required folders
+     * 
+     * @return void
+     */
+    protected function createFolders($baseFolder)
+    {
+        // get plural from model name
+        $pluralModel = str_plural($this->model);
+         // create container folder
+        $this->filesystem->makeDirectory(app_path($baseFolder."/{$pluralModel}"));
+         // add requests folder
+        $this->filesystem->makeDirectory(app_path($baseFolder."/{$pluralModel}/Requests"));
+         // add repositories folder
+        $this->filesystem->makeDirectory(app_path($baseFolder."/{$pluralModel}/Repositories/"));
+         // add Interfaces folder
+        $this->filesystem->makeDirectory(app_path($baseFolder."/{$pluralModel}/Repositories/Interfaces"));
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -13,7 +13,7 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
-        //
+        Commands\LaraStructure::class
     ];
 
     /**

--- a/app/Console/Stubs/DummyModel.stub
+++ b/app/Console/Stubs/DummyModel.stub
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Shop\Dummies;
+
+class Dummy extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+    	// 
+    ];
+
+    /**
+     * The attributes that should be hidden for arrays.
+     *
+     * @var array
+     */
+    protected $hidden = [
+    	// 
+    ];
+}

--- a/app/Console/Stubs/DummyRepository.stub
+++ b/app/Console/Stubs/DummyRepository.stub
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Shop\Dummies\Repositories;
+
+use App\Shop\Dummies\Dummy;
+use Illuminate\Support\Collection;
+use Jsdecena\Baserepo\BaseRepository;
+use Illuminate\Database\QueryException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use App\Shop\Dummies\Repositories\Interfaces\DummyRepositoryInterface;
+
+class DummyRepository extends BaseRepository implements DummyRepositoryInterface
+{
+	/**
+     * DummyRepository constructor.
+     * 
+     * @param Dummy $dummy
+     */
+    public function __construct(Dummy $dummy)
+    {
+        parent::__construct($dummy);
+        $this->model = $dummy;
+    }
+
+    /**
+     * List all the Dummies
+     *
+     * @param string $order
+     * @param string $sort
+     * @param array $except
+     * @return \Illuminate\Support\Collection
+     */
+    public function listDummies(string $order = 'id', string $sort = 'desc', $except = []) : Collection
+    {
+        return $this->model->orderBy($order, $sort)->get()->except($except);
+    }
+
+    /**
+     * Create Dummy
+     *
+     * @param array $params
+     *
+     * @return Dummy
+     * @throws InvalidArgumentException
+     */
+    public function createDummy(array $params) : Dummy
+    {
+        try {
+        	return Dummy::create($params);
+        } catch (QueryException $e) {
+            throw new InvalidArgumentException($e->getMessage());
+        }
+    }
+
+    /**
+     * Update the dummy
+     *
+     * @param array $params
+     * @return Dummy
+     */
+    public function updateDummy(array $params) : Dummy
+    {
+        $dummy = $this->findDummyById($this->model->id);
+        $dummy->update($params);
+        return $dummy;
+    }
+
+    /**
+     * @param int $id
+     * 
+     * @return Dummy
+     * @throws ModelNotFoundException
+     */
+    public function findDummyById(int $id) : Dummy
+    {
+        try {
+            return $this->findOneOrFail($id);
+        } catch (ModelNotFoundException $e) {
+            throw new ModelNotFoundException($e->getMessage());
+        }
+    }
+
+    /**
+     * Delete a dummy
+     *
+     * @return bool
+     */
+    public function deleteDummy() : bool
+    {
+        return $this->model->delete();
+    }
+}

--- a/app/Console/Stubs/DummyRepositoryInterface.stub
+++ b/app/Console/Stubs/DummyRepositoryInterface.stub
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Shop\Dummies\Repositories\Interfaces;
+
+use App\Shop\Dummies\Dummy;
+use Illuminate\Support\Collection;
+use Jsdecena\Baserepo\BaseRepositoryInterface;
+
+interface DummyRepositoryInterface extends BaseRepositoryInterface
+{
+    public function listDummies(string $order = 'id', string $sort = 'desc', $except = []) : Collection;
+
+    public function createDummy(array $params) : Dummy;
+
+    public function updateDummy(array $params) : Dummy;
+
+    public function findDummyById(int $id) : Dummy;
+    
+    public function deleteDummy() : bool;
+}

--- a/app/Shop/Categories/Repositories/CategoryRepository.php
+++ b/app/Shop/Categories/Repositories/CategoryRepository.php
@@ -115,12 +115,23 @@ class CategoryRepository extends BaseRepository implements CategoryRepositoryInt
         }
 
         $merge = $collection->merge(compact('slug', 'cover'));
-        if (isset($params['parent'])) {
+
+        // set parent attribute default value if not set
+        $params['parent'] = $params['parent'] ?? 0;
+
+        // If parent category is not set on update
+        // just make current category as root
+        // else we need to find the parent
+        // and associate it as child
+        if ( (int)$params['parent'] == 0) {
+            $category->saveAsRoot();
+        } else {
             $parent = $this->findCategoryById($params['parent']);
             $category->parent()->associate($parent);
         }
 
         $category->update($merge->all());
+        
         return $category;
     }
 

--- a/resources/views/admin/categories/create.blade.php
+++ b/resources/views/admin/categories/create.blade.php
@@ -11,6 +11,7 @@
                     <div class="form-group">
                         <label for="parent">Parent Category</label>
                         <select name="parent" id="parent" class="form-control select2">
+                            <option value="">-- Select --</option>
                             @foreach($categories as $category)
                                 <option value="{{ $category->id }}">{{ $category->name }}</option>
                             @endforeach

--- a/resources/views/admin/categories/edit.blade.php
+++ b/resources/views/admin/categories/edit.blade.php
@@ -12,6 +12,7 @@
                     <div class="form-group">
                         <label for="parent">Parent Category</label>
                         <select name="parent" id="parent" class="form-control select2">
+                            <option value="0">No parent</option>
                             @foreach($categories as $cat)
                                 <option @if($cat->id == $category->parent_id) selected="selected" @endif value="{{$cat->id}}">{{$cat->name}}</option>
                             @endforeach

--- a/tests/Unit/ArtisanCommands.php
+++ b/tests/Unit/ArtisanCommands.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class ArtisanCommands extends TestCase
+{
+    /** @test */
+    public function it_can_generate_files()
+    {
+	    $this->artisan('make:structure Test')
+	    	->expectsOutput('File structure for Test created.')
+	    	->assertExitCode();
+    }
+}


### PR DESCRIPTION
### Feature: Generate model and repository for base shop

When you want to use the same method that base shop is structured with. You have to create the repositories, requests under a folder called the same as model name but plural. 

This PR helps to reduce this time you lose when creating your model repository and interface relate.