### PR TITLE
added transaction in order to improve seeding time to a few seconds

### DIFF
--- a/database/seeds/USCitiesTableSeeder.php
+++ b/database/seeds/USCitiesTableSeeder.php
@@ -7,6 +7,7 @@ class USCitiesTableSeeder extends Seeder
 {
     public function run()
     {
+        DB::beginTransaction();
         DB::unprepared("
 INSERT INTO `cities` VALUES ('Aaronsburg', 'PA', null);
 INSERT INTO `cities` VALUES ('Abbeville', 'AL', null);
@@ -29745,7 +29746,8 @@ INSERT INTO `cities` VALUES ('Zuni', 'NM', null);
 INSERT INTO `cities` VALUES ('Zuni', 'VA', null);
 INSERT INTO `cities` VALUES ('Zurich', 'MT', null);
 INSERT INTO `cities` VALUES ('Zwingle', 'IA', null);
-INSERT INTO `cities` VALUES ('Zwolle', 'LA', null);        
+INSERT INTO `cities` VALUES ('Zwolle', 'LA', null);
         ");
+        DB::commit();
     }
 }


### PR DESCRIPTION
# Title of the PR
added transaction in order to improve seeding time to a few seconds

## Description of the PR with the link on the issue trying to solve
Added transaction to `USCitiesTableSeeder` in order to improve the time spent to seed USCitiesTableSeeder during migration. This PR increases the speed of migration during new installation from almost half an hour to a few seconds!
