### PR TITLE
Fixed parameters

### DIFF
--- a/app/Http/Controllers/Front/CustomerAddressController.php
+++ b/app/Http/Controllers/Front/CustomerAddressController.php
@@ -100,7 +100,7 @@ class CustomerAddressController extends Controller
      *
      * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
      */
-    public function edit($addressId)
+    public function edit($customerId, $addressId)
     {
         $countries = $this->countryRepo->listCountries();
 
@@ -141,7 +141,7 @@ class CustomerAddressController extends Controller
      * @return \Illuminate\Http\RedirectResponse
      * @throws \Exception
      */
-    public function destroy($addressId)
+    public function destroy($customerId, $addressId)
     {
         $address = $this->addressRepo->findCustomerAddressById($addressId, auth()->user());
 


### PR DESCRIPTION
# Title of the PR
Address Id is being replaced by CustomerId
## Description of the PR with the link on the issue trying to solve

When editing or deleting addresses, `CustomerAddressController@edit` is only accepting one parameter, `$addressId` however, that is actually the customer id being used. Throws an `Address not found.` exception.


