### PR TITLE
Does not have 'name' attribute on city or province

### DIFF
--- a/resources/views/admin/orders/edit.blade.php
+++ b/resources/views/admin/orders/edit.blade.php
@@ -164,12 +164,12 @@
                                     <td>{{ $order->address->address_2 }}</td>
                                     <td>
                                         @if(isset($order->address->city))
-                                            {{ $order->address->city->name }}
+                                            {{ $order->address->city }}
                                         @endif
                                     </td>
                                     <td>
                                         @if(isset($order->address->province))
-                                            {{ $order->address->province->name }}
+                                            {{ $order->address->province }}
                                         @endif
                                     </td>
                                     <td>{{ $order->address->zip }}</td>


### PR DESCRIPTION
# Title of the PR

City and Province do not have name attribute 

## Description of the PR with the link on the issue trying to solve

`resources/views/admin/orders/edit.blade.php:164`

```blade
   ...
   <tr>
    <tr>
        <td>{{ $order->address->address_1 }}</td>
        <td>{{ $order->address->address_2 }}</td>
        <td>
            @if(isset($order->address->city))
                {{ $order->address->city }} {{-- $order->address->city->name --}}
            @endif
        </td>
        <td>
            @if(isset($order->address->province))
                {{ $order->address->province->name }} {{-- $order->address->province->name --}}
            @endif
        </td>
        <td>{{ $order->address->zip }}</td>
    </tr>
...

```