### PR TITLE
Wrong PR

### DIFF
--- a/app/Http/Controllers/Admin/Orders/OrderController.php
+++ b/app/Http/Controllers/Admin/Orders/OrderController.php
@@ -93,7 +93,7 @@ class OrderController extends Controller
     {
         $order = $this->orderRepo->findOrderById($orderId);
         $order->courier = $this->courierRepo->findCourierById($order->courier_id);
-        $order->address = $this->addressRepo->findAddressById($order->address_id);
+        $order->address = $this->addressRepo->findAddressById($order->address_id, true);
 
         $orderRepo = new OrderRepository($order);
 
@@ -118,7 +118,7 @@ class OrderController extends Controller
     {
         $order = $this->orderRepo->findOrderById($orderId);
         $order->courier = $this->courierRepo->findCourierById($order->courier_id);
-        $order->address = $this->addressRepo->findAddressById($order->address_id);
+        $order->address = $this->addressRepo->findAddressById($order->address_id, true);
 
         $orderRepo = new OrderRepository($order);
 

--- a/app/Shop/Addresses/Repositories/AddressRepository.php
+++ b/app/Shop/Addresses/Repositories/AddressRepository.php
@@ -94,13 +94,17 @@ class AddressRepository extends BaseRepository implements AddressRepositoryInter
      * Return the address
      *
      * @param int $id
+     * @param bool $withSoftDeletes
      *
      * @return Address
      * @throws AddressNotFoundException
      */
-    public function findAddressById(int $id) : Address
+    public function findAddressById(int $id, bool $withSoftDeletes = false) : Address
     {
         try {
+            if(isset($withSoftDeletes)) {
+                return Address::withTrashed()->where('id', $id)->firstOrFail();
+            }
             return $this->findOneOrFail($id);
         } catch (ModelNotFoundException $e) {
             throw new AddressNotFoundException('Address not found.');

--- a/app/Shop/Addresses/Repositories/Interfaces/AddressRepositoryInterface.php
+++ b/app/Shop/Addresses/Repositories/Interfaces/AddressRepositoryInterface.php
@@ -22,7 +22,7 @@ interface AddressRepositoryInterface extends BaseRepositoryInterface
 
     public function listAddress(string $order = 'id', string $sort = 'desc', array $columns = ['*']) : Collection;
 
-    public function findAddressById(int $id) : Address;
+    public function findAddressById(int $id, bool $withSoftDeletes) : Address;
 
     public function findCustomer() : Customer;
 

--- a/resources/views/admin/orders/edit.blade.php
+++ b/resources/views/admin/orders/edit.blade.php
@@ -164,12 +164,12 @@
                                     <td>{{ $order->address->address_2 }}</td>
                                     <td>
                                         @if(isset($order->address->city))
-                                            {{ $order->address->city->name }}
+                                            {{ $order->address->city }}
                                         @endif
                                     </td>
                                     <td>
                                         @if(isset($order->address->province))
-                                            {{ $order->address->province->name }}
+                                            {{ $order->address->province }}
                                         @endif
                                     </td>
                                     <td>{{ $order->address->zip }}</td>


### PR DESCRIPTION
Wrong PR sry

> # Title of the PR
> 
> Admin/Orders/show or /edit will throw error if user deletes address
> 
> ## Description of the PR with the link on the issue trying to solve
> 
> If a user deletes their address and has placed an order, `Address Not Found` exception is thrown from `Admin/Orders/OrderController@edit()` and `Admin/Orders/OrderControlller@show`.
> 
> This is caused because [soft delete needs to be explicitly stated in the query](https://laravel.com/docs/5.7/eloquent#querying-soft-deleted-models) inside `\App\Shop\Addresses\Repositories\AddressRepository::findAddressById`. 
> 
> ### Other
> 
> Not sure if this the best approach, but it works. Any suggestions?
