### PR TITLE
Fix cutomer address delete

### DIFF
--- a/app/Http/Controllers/Front/CustomerAddressController.php
+++ b/app/Http/Controllers/Front/CustomerAddressController.php
@@ -145,7 +145,8 @@ class CustomerAddressController extends Controller
     {
         $address = $this->addressRepo->findCustomerAddressById($addressId, auth()->user());
 
-        $address->delete();
+        $address->status=0;
+        $address->save();
 
         return redirect()->route('customer.address.index', $customerId)
             ->with('message', 'Address delete successful');


### PR DESCRIPTION
# Title of the PR
 Solution for issue #179 

## Description of the PR with the link on the issue trying to solve

If an order's address is deleted by the customer, an application error raises with exception AddressNotFoundException. The address is no more soft deleted, but changed its state from enable to disable.