### PR TITLE
User erroneously redirected to admin view

### DIFF
--- a/app/Http/Controllers/Front/CustomerAddressController.php
+++ b/app/Http/Controllers/Front/CustomerAddressController.php
@@ -53,7 +53,7 @@ class CustomerAddressController extends Controller
     }
 
     /**
-     * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
+     * @return \Illuminate\Http\RedirectResponse
      */
     public function index()
     {
@@ -148,7 +148,6 @@ class CustomerAddressController extends Controller
        else {
              $address->delete();
        }
-
         return redirect()->route('accounts', ['tab' => 'address'])
             ->with('message', 'Address delete successful');
     }

--- a/app/Http/Controllers/Front/CustomerAddressController.php
+++ b/app/Http/Controllers/Front/CustomerAddressController.php
@@ -57,12 +57,8 @@ class CustomerAddressController extends Controller
      */
     public function index()
     {
-        $customer = auth()->user();
 
-        return view('front.customers.addresses.list', [
-            'customer' => $customer,
-            'addresses' => $customer->addresses
-        ]);
+        return redirect()->route('accounts', ['tab' => 'address']);
     }
 
     /**
@@ -153,7 +149,7 @@ class CustomerAddressController extends Controller
              $address->delete();
        }
 
-        return redirect()->route('customer.address.index', $customerId)
+        return redirect()->route('accounts', ['tab' => 'address'])
             ->with('message', 'Address delete successful');
     }
 }

--- a/tests/Feature/Front/CustomerAddresses/CustomerAddressFeatureTest.php
+++ b/tests/Feature/Front/CustomerAddresses/CustomerAddressFeatureTest.php
@@ -22,12 +22,8 @@ class CustomerAddressFeatureTest extends TestCase
         $this
             ->actingAs($this->customer, 'web')
             ->get(route('customer.address.index', $this->customer->id))
-            ->assertStatus(200)
-            ->assertSee('Alias')
-            ->assertSee('Address 1')
-            ->assertSee('Country')
-            ->assertSee('City')
-            ->assertSee('Zip Code');
+            ->assertStatus(302)
+            ->assertRedirect(route('accounts', ['tab' => 'address']));
     }
 
     /** @test */


### PR DESCRIPTION
# Title of the PR
Fix for issue #180

## Description of the PR with the link on the issue trying to solve
Customer is redirected to admin view when he deletes one of his addresses.
