### PR TITLE
Wrong address taken at checkout

### DIFF
--- a/resources/views/front/accounts.blade.php
+++ b/resources/views/front/accounts.blade.php
@@ -139,7 +139,7 @@
                                         <tr>
                                             <td>{{$address->alias}}</td>
                                             <td>{{$address->address_1}}</td>
-                                            <td>{{$address->address_1}}</td>
+                                            <td>{{$address->address_2}}</td>
                                             <td>{{$address->city}}</td>
                                             @if(isset($address->province))
                                             <td>{{$address->province->name}}</td>

--- a/resources/views/front/payments/bank-transfer.blade.php
+++ b/resources/views/front/payments/bank-transfer.blade.php
@@ -23,8 +23,13 @@
 </tr>
 <script type="text/javascript">
     $(document).ready(function () {
-        let billingAddressId = $('input[name="billing_address"]').val();
+        let billingAddressId = $('input[name="billing_address"]:checked').val();
         $('.billing_address').val(billingAddressId);
+
+        $('input[name="billing_address"]').on('change', function () {
+          billingAddressId = $('input[name="billing_address"]:checked').val();
+          $('.billing_address').val(billingAddressId);
+        });
 
         let courierRadioBtn = $('input[name="rate"]');
         courierRadioBtn.click(function () {

--- a/resources/views/front/payments/paypal.blade.php
+++ b/resources/views/front/payments/paypal.blade.php
@@ -24,8 +24,13 @@
 </tr>
 <script type="text/javascript">
     $(document).ready(function () {
-        let billingAddressId = $('input[name="billing_address"]').val();
+        let billingAddressId = $('input[name="billing_address"]:checked').val();
         $('.billing_address').val(billingAddressId);
+
+        $('input[name="billing_address"]').on('change', function () {
+          billingAddressId = $('input[name="billing_address"]:checked').val();
+          $('.billing_address').val(billingAddressId);
+        });
 
         let courierRadioBtn = $('input[name="rate"]');
         courierRadioBtn.click(function () {


### PR DESCRIPTION
# Title of the PR
Fix for issue #185 

## Description of the PR with the link on the issue trying to solve
If user has more addresses defined, alwais the first one is picked up for delivery address. This PR also solve a second issue: a worng Address 2 is shown in customer address account page.