### PR TITLE
Allow billing/delivery address for non stripe credit card payement

### DIFF
--- a/resources/views/front/checkout.blade.php
+++ b/resources/views/front/checkout.blade.php
@@ -144,3 +144,69 @@
         @endif
     </div>
 @endsection
+@section('js')
+    <script type="text/javascript">
+
+        function setTotal(total, shippingCost) {
+            let computed = +shippingCost + parseFloat(total);
+            $('#total').html(computed.toFixed(2));
+        }
+
+        function setShippingFee(cost) {
+            el = '#shippingFee';
+            $(el).html(cost);
+            $('#shippingFeeC').val(cost);
+        }
+
+        function setCourierDetails(courierId) {
+            $('.courier_id').val(courierId);
+        }
+
+        $(document).ready(function () {
+
+            let clicked = false;
+
+            $('#sameDeliveryAddress').on('change', function () {
+                clicked = !clicked;
+                if (clicked) {
+                    $('#sameDeliveryAddressRow').show();
+                } else {
+                    $('#sameDeliveryAddressRow').hide();
+                }
+            });
+
+            let billingAddress = 'input[name="billing_address"]';
+            $(billingAddress).on('change', function () {
+                let chosenAddressId = $(this).val();
+                $('.address_id').val(chosenAddressId);
+                $('.delivery_address_id').val(chosenAddressId);
+            });
+
+            let deliveryAddress = 'input[name="delivery_address"]';
+            $(deliveryAddress).on('change', function () {
+                let chosenDeliveryAddressId = $(this).val();
+                $('.delivery_address_id').val(chosenDeliveryAddressId);
+            });
+
+            let courier = 'input[name="courier"]';
+            $(courier).on('change', function () {
+                let shippingCost = $(this).data('cost');
+                let total = $('#total').data('total');
+
+                setCourierDetails($(this).val());
+                setShippingFee(shippingCost);
+                setTotal(total, shippingCost);
+            });
+
+            if ($(courier).is(':checked')) {
+                let shippingCost = $(courier + ':checked').data('cost');
+                let courierId = $(courier + ':checked').val();
+                let total = $('#total').data('total');
+
+                setShippingFee(shippingCost);
+                setCourierDetails(courierId);
+                setTotal(total, shippingCost);
+            }
+        });
+    </script>
+@endsection

--- a/resources/views/front/payments/stripe.blade.php
+++ b/resources/views/front/payments/stripe.blade.php
@@ -25,71 +25,10 @@
         @endif
     </td>
 </tr>
-@section('js')
     <script src="{{ url('https://checkout.stripe.com/checkout.js') }}"></script>
     <script type="text/javascript">
 
-        function setTotal(total, shippingCost) {
-            let computed = +shippingCost + parseFloat(total);
-            $('#total').html(computed.toFixed(2));
-        }
-
-        function setShippingFee(cost) {
-            el = '#shippingFee';
-            $(el).html(cost);
-            $('#shippingFeeC').val(cost);
-        }
-
-        function setCourierDetails(courierId) {
-            $('.courier_id').val(courierId);
-        }
-
         $(document).ready(function () {
-
-            let clicked = false;
-
-            $('#sameDeliveryAddress').on('change', function () {
-                clicked = !clicked;
-                if (clicked) {
-                    $('#sameDeliveryAddressRow').show();
-                } else {
-                    $('#sameDeliveryAddressRow').hide();
-                }
-            });
-
-            let billingAddress = 'input[name="billing_address"]';
-            $(billingAddress).on('change', function () {
-                let chosenAddressId = $(this).val();
-                $('.address_id').val(chosenAddressId);
-                $('.delivery_address_id').val(chosenAddressId);
-            });
-
-            let deliveryAddress = 'input[name="delivery_address"]';
-            $(deliveryAddress).on('change', function () {
-                let chosenDeliveryAddressId = $(this).val();
-                $('.delivery_address_id').val(chosenDeliveryAddressId);
-            });
-
-            let courier = 'input[name="courier"]';
-            $(courier).on('change', function () {
-                let shippingCost = $(this).data('cost');
-                let total = $('#total').data('total');
-
-                setCourierDetails($(this).val());
-                setShippingFee(shippingCost);
-                setTotal(total, shippingCost);
-            });
-
-            if ($(courier).is(':checked')) {
-                let shippingCost = $(courier + ':checked').data('cost');
-                let courierId = $(courier + ':checked').val();
-                let total = $('#total').data('total');
-
-                setShippingFee(shippingCost);
-                setCourierDetails(courierId);
-                setTotal(total, shippingCost);
-            }
-
             let handler = StripeCheckout.configure({
                 key: "{{ config('stripe.key') }}",
                 locale: 'auto',
@@ -123,4 +62,3 @@
             });
         });
     </script>
-@endsection


### PR DESCRIPTION
# Title of the PR
Fix for issue #193

## Description of the PR with the link on the issue trying to solve
Just rearrangement of javascript file. This allow billing/delivery address of being loaded in the checkout page even if the stripe option become not used in .env file.

  Still remain the problem where delivery selected address is not used when user selects bank-transfer payement method.